### PR TITLE
use resource close in test, and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ for (Row r : reader) {
 }
 ```
 
-The StreamingReader is an autoclosable resource, and it's important that you close it to free the filesystem resource it consumed. With Java 7, you can do this:
+The StreamingReader is an autoclosable resource, and it's important that you close it to free the filesystem resource it consumed.
+You have to call **close** on reader like this:
 
 ```java
 try (
@@ -64,6 +65,7 @@ try (
       System.out.println(c.getStringCellValue());
     }
   }
+  reader.close(); // !!
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ The StreamingReader is an autoclosable resource, and it's important that you clo
 You have to call **close** on reader like this:
 
 ```java
-try (
+
   InputStream is = new FileInputStream(new File("/path/to/workbook.xlsx"));
   StreamingReader reader = StreamingReader.builder()
           .rowCacheSize(100)
           .bufferSize(4096)
           .sheetIndex(0)
           .read(is);
-) {
+
   for (Row r : reader) {
     for (Cell c : r) {
       System.out.println(c.getStringCellValue());

--- a/src/main/java/br/com/beardsoft/xlsx/StreamingReader.java
+++ b/src/main/java/br/com/beardsoft/xlsx/StreamingReader.java
@@ -164,7 +164,7 @@ public class StreamingReader implements Iterable<Row> {
   /**
    * Closes the streaming resource, attempting to clean up any temporary files created.
    *
-   * @throws com.monitorjbl.xlsx.exceptions.CloseException if there is an issue closing the stream
+   * @throws br.com.beardsoft.xlsx.exceptions.CloseException if there is an issue closing the stream
    */
   public void close() {
     try {
@@ -174,8 +174,8 @@ public class StreamingReader implements Iterable<Row> {
     }
 
     if (tmp != null) {
-      log.debug("Deleting tmp file [" + tmp.getAbsolutePath() + "]");
-      tmp.delete();
+       log.debug("Deleting tmp file [" + tmp.getAbsolutePath() + "]");
+       tmp.delete();
     }
   }
 
@@ -271,7 +271,7 @@ public class StreamingReader implements Iterable<Row> {
      *
      * @param is input stream to read in
      * @return built streaming reader instance
-     * @throws com.monitorjbl.xlsx.exceptions.ReadException if there is an issue reading the stream
+     * @throws br.com.beardsoft.xlsx.exceptions.ReadException if there is an issue reading the stream
      */
     public StreamingReader read(InputStream is) {
       File f = null;
@@ -296,8 +296,8 @@ public class StreamingReader implements Iterable<Row> {
      *
      * @param f file to read in
      * @return built streaming reader instance
-     * @throws com.monitorjbl.xlsx.exceptions.OpenException if there is an issue opening the file
-     * @throws com.monitorjbl.xlsx.exceptions.ReadException if there is an issue reading the file
+     * @throws br.com.beardsoft.xlsx.exceptions.OpenException if there is an issue opening the file
+     * @throws br.com.beardsoft.xlsx.exceptions.ReadException if there is an issue reading the file
      */
     public StreamingReader read(File f) {
       try {

--- a/src/test/java/br/com/beardsoft/xlsx/StreamingReaderTest.java
+++ b/src/test/java/br/com/beardsoft/xlsx/StreamingReaderTest.java
@@ -52,6 +52,9 @@ public class StreamingReaderTest {
 			}
 			obj.add(o);
 		}
+        
+        // delete temp files
+        reader.close();
 
 		assertEquals(6, obj.size());
 		List<Cell> row;
@@ -124,6 +127,9 @@ public class StreamingReaderTest {
 			obj.add(o);
 		}
 
+        // delete temp files
+        reader.close();
+        
 		assertEquals(2, obj.size());
 		List<Cell> row;
 
@@ -169,7 +175,10 @@ public class StreamingReaderTest {
 			}
 			obj.add(o);
 		}
-
+        
+        // delete temp files
+        reader.close();
+        
 		assertEquals(1, obj.size());
 		List<Cell> row;
 
@@ -196,6 +205,9 @@ public class StreamingReaderTest {
 			obj.add(o);
 		}
 
+        // delete temp files
+        reader.close();
+        
 		assertEquals(1, obj.size());
 		List<Cell> row;
 
@@ -222,6 +234,9 @@ public class StreamingReaderTest {
 			obj.add(o);
 		}
 
+        // delete temp files
+        reader.close();
+        
 		assertEquals(1, obj.size());
 		List<Cell> row;
 
@@ -248,6 +263,9 @@ public class StreamingReaderTest {
 			obj.add(o);
 		}
 
+        // delete temp files
+        reader.close();
+        
 		assertEquals(1, obj.size());
 		List<Cell> row;
 
@@ -263,6 +281,8 @@ public class StreamingReaderTest {
 				"src/test/resources/sheets.xlsx"));
 		StreamingReader reader = StreamingReader.builder()
 				.sheetName("adsfasdfasdfasdf").read(is);
+        // delete temp files
+        reader.close();
 		fail("Should have failed");
 	}
 
@@ -273,6 +293,8 @@ public class StreamingReaderTest {
 		try {
 			StreamingReader reader = StreamingReader.builder()
 					.sheetName("adsfasdfasdfasdf").read(f);
+            // delete temp files
+            reader.close();
 			fail("Should have failed");
 		} catch (MissingSheetException e) {
 			assertTrue(f.exists());


### PR DESCRIPTION
Highlight the need of manually call close on reader in documentation, and put these close -es to the test.